### PR TITLE
Fix axios config typo

### DIFF
--- a/client/api/build-client.js
+++ b/client/api/build-client.js
@@ -14,7 +14,7 @@ const buildClient = ({req}) =>{
       } else {
         // We must be on the browser
         return axios.create({
-          baseUrl: '/',
+          baseURL: '/',
         });
       }
 };


### PR DESCRIPTION
## Summary
- fix `baseURL` typo in frontend API client

## Testing
- `npm test` *(fails: mongodb-memory-server can't download binary for ubuntu 24.04)*

------
https://chatgpt.com/codex/tasks/task_e_6844f748de5c8320b9b84f834e0cad9e