### PR TITLE
Update signout test to verify session cleared

### DIFF
--- a/auth/src/routes/__test__/signout.test.ts
+++ b/auth/src/routes/__test__/signout.test.ts
@@ -18,4 +18,12 @@ it('clears the cookies after signing out', async () =>{
     expect(response.get('Set-Cookie')[0]).toEqual(
         'express:sess=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly'
     )
+
+    const currentUserResponse = await request(app)
+        .get('/api/users/currentuser')
+        .set('Cookie', response.get('Set-Cookie'))
+        .send()
+        .expect(200);
+
+    expect(currentUserResponse.body.currentUser).toEqual(null);
 });


### PR DESCRIPTION
## Summary
- check `/currentuser` after signing out to verify session cookie was cleared

## Testing
- `npm test --silent` *(fails: MongoDB binaries download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8ab16108320a535f209c6e7066a